### PR TITLE
SDK bankCode parameter propagation bugfix

### DIFF
--- a/ni_sdk/build.gradle
+++ b/ni_sdk/build.gradle
@@ -82,7 +82,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.network-international'
             artifactId = 'card-management-sdk-android'
-            version = '1.0.26'
+            version = '1.0.27'
             afterEvaluate {
                 from components.release
             }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/CardDetailsUseCases.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/CardDetailsUseCases.kt
@@ -23,12 +23,21 @@ class CardDetailsUseCases(private val cardDetailsRepository: CardDetailsReposito
         val keyPair = CryptoManager.generateRsaKeyPair(CryptoManager.KEY_LENGTH_BITS_4K)
         val cardDetailsResponse = cardDetailsRepository.getSecuredCardDetails(
             input.connectionProperties.token,
+            input.bankCode,
             input.cardIdentifierId,
             input.cardIdentifierType,
             getX509CertificateDto(keyPair)
         )
 
         return decodeToNICardDetailsResponse(cardDetailsResponse, keyPair)
+    }
+
+    private fun getX509CertificateDto(keyPair: KeyPair): X509CertificateBodyDto {
+        val certificate = SelfSignedCertificate(
+            fqdn = BuildConfig.LIBRARY_PACKAGE_NAME,
+            keyPair = keyPair
+        )
+        return X509CertificateBodyDto(certificate.certificateBase64String)
     }
 
     private fun decodeToNICardDetailsResponse(response: CardDetailsResponse, keyPair: KeyPair): NICardDetailsResponse {
@@ -52,14 +61,6 @@ class CardDetailsUseCases(private val cardDetailsRepository: CardDetailsReposito
             clearCvv,
             response.clearCardholderName
         )
-    }
-
-    private fun getX509CertificateDto(keyPair: KeyPair): X509CertificateBodyDto {
-        val certificate = SelfSignedCertificate(
-            fqdn = BuildConfig.LIBRARY_PACKAGE_NAME,
-            keyPair = keyPair
-        )
-        return X509CertificateBodyDto(certificate.certificateBase64String)
     }
 
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/ChangePinUseCases.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/ChangePinUseCases.kt
@@ -26,6 +26,7 @@ class ChangePinUseCases(private val changePinRepository: IChangePinRepository) :
         // get the object that holds the encrypted PAN
         val cardIdentifierModel = changePinRepository.getCardsLookUp(
             input.connectionProperties.token,
+            input.bankCode,
             CardIdentifierBodyDto(
                 input.cardIdentifierType,
                 input.cardIdentifierId,
@@ -34,7 +35,7 @@ class ChangePinUseCases(private val changePinRepository: IChangePinRepository) :
         )
 
         // get generated x.509.Certificate from NI API Gateway
-        val certificateModel = changePinRepository.getCertificateFromApiGateway(input.connectionProperties.token)
+        val certificateModel = changePinRepository.getCertificateFromApiGateway(input.connectionProperties.token, input.bankCode)
 
         // decrypt encrypted PAN to clear PAN
         val clearPan = decryptToClearPan(cardIdentifierModel, keyPair.private)
@@ -54,6 +55,7 @@ class ChangePinUseCases(private val changePinRepository: IChangePinRepository) :
         // call API to Change Pin (send encrypted pin blocks) ("encrypted_old_pin":"encrypted old pin block", "encrypted_new_pin":"encrypted new pin block")
         changePinRepository.changePin(
             input.connectionProperties.token,
+            input.bankCode,
             ChangePinBodyDto(
                 input.cardIdentifierId,
                 encryptedOldPinBlock,

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/SetPinUseCases.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/domain/usecases/implementation/SetPinUseCases.kt
@@ -25,6 +25,7 @@ class SetPinUseCases(private val setPinRepository: ISetPinRepository) : ISetPinU
         //get the object that holds the encrypted PAN
         val cardIdentifierModel = setPinRepository.getCardsLookUp(
             input.connectionProperties.token,
+            input.bankCode,
             CardIdentifierBodyDto(
                 input.cardIdentifierType,
                 input.cardIdentifierId,
@@ -33,7 +34,7 @@ class SetPinUseCases(private val setPinRepository: ISetPinRepository) : ISetPinU
         )
 
         // get their generated x.509.Certificate
-        val certificateModel = setPinRepository.getPinCertificate(input.connectionProperties.token)
+        val certificateModel = setPinRepository.getPinCertificate(input.connectionProperties.token, input.bankCode)
 
         // decrypt encrypted PAN to clear PAN
         val clearPan = decryptToClearPan(cardIdentifierModel, keyPair.private)
@@ -47,6 +48,7 @@ class SetPinUseCases(private val setPinRepository: ISetPinRepository) : ISetPinU
         //call API to Set Pin (send encrypted pin block) ("encrypted_pin":"encrypted pin block")
         setPinRepository.setPin(
             input.connectionProperties.token,
+            input.bankCode,
             SetPinBodyDto(
                 input.cardIdentifierId,
                 encryptedPinBlock,

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/CardDetailsRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/CardDetailsRepository.kt
@@ -7,13 +7,13 @@ import ae.network.nicardmanagementsdk.network.dto.card_details.asDomainModel
 import ae.network.nicardmanagementsdk.network.retrofit_api.CardDetailsApi
 import ae.network.nicardmanagementsdk.repository.interfaces.ICardDetailsRepository
 
-const val FINANCIAL_ID = "EAND"
 const val CHANNEL_ID = "sdk"
 
 class CardDetailsRepository(private val cardDetailsApi: CardDetailsApi) : ICardDetailsRepository {
 
     override suspend fun getSecuredCardDetails(
         token: String,
+        bankCode: String,
         cardIdentifierId: String,
         cardIdentifierType: String,
         certificate: X509CertificateBodyDto
@@ -25,7 +25,7 @@ class CardDetailsRepository(private val cardDetailsApi: CardDetailsApi) : ICardD
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             ),
             cardIdentifierId,

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/ChangePinRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/ChangePinRepository.kt
@@ -12,6 +12,7 @@ import ae.network.nicardmanagementsdk.repository.interfaces.IChangePinRepository
 class ChangePinRepository(private val changePinApi: ChangePinApi) : IChangePinRepository {
     override suspend fun getCardsLookUp(
         authToken: String,
+        bankCode: String,
         cardIdentifierBody: CardIdentifierBodyDto
     ): CardIdentifierModel {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
@@ -21,14 +22,14 @@ class ChangePinRepository(private val changePinApi: ChangePinApi) : IChangePinRe
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             ),
             cardIdentifierBody
         ).asDomainModel()
     }
 
-    override suspend fun getCertificateFromApiGateway(authToken: String): PinCertificateModel {
+    override suspend fun getCertificateFromApiGateway(authToken: String, bankCode: String): PinCertificateModel {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
         return changePinApi.getPinCertificate(
             mapOf(
@@ -36,13 +37,13 @@ class ChangePinRepository(private val changePinApi: ChangePinApi) : IChangePinRe
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             )
         ).asDomainModel()
     }
 
-    override suspend fun changePin(authToken: String, changePinBody: ChangePinBodyDto) {
+    override suspend fun changePin(authToken: String, bankCode: String, changePinBody: ChangePinBodyDto) {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
         changePinApi.changePin(
             mapOf(
@@ -50,7 +51,7 @@ class ChangePinRepository(private val changePinApi: ChangePinApi) : IChangePinRe
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             ),
             changePinBody

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/SetPinRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/implementation/SetPinRepository.kt
@@ -13,6 +13,7 @@ class SetPinRepository(private val setPinApi: SetPinApi) : ISetPinRepository {
 
     override suspend fun getCardsLookUp(
         token: String,
+        bankCode: String,
         cardIdentifierBody: CardIdentifierBodyDto
     ): CardIdentifierModel {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
@@ -22,14 +23,14 @@ class SetPinRepository(private val setPinApi: SetPinApi) : ISetPinRepository {
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             ),
             cardIdentifierBody
         ).asDomainModel()
     }
 
-    override suspend fun getPinCertificate(token: String): PinCertificateModel {
+    override suspend fun getPinCertificate(token: String, bankCode: String): PinCertificateModel {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
         return setPinApi.getPinCertificate(
             mapOf(
@@ -37,13 +38,13 @@ class SetPinRepository(private val setPinApi: SetPinApi) : ISetPinRepository {
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             )
         ).asDomainModel()
     }
 
-    override suspend fun setPin(token: String, setPinBody: SetPinBodyDto) {
+    override suspend fun setPin(token: String, bankCode: String, setPinBody: SetPinBodyDto) {
         val uniqueReferenceCode = CryptoManager.uniqueReferenceCodeRandom()
         setPinApi.setPin(
             mapOf(
@@ -51,7 +52,7 @@ class SetPinRepository(private val setPinApi: SetPinApi) : ISetPinRepository {
                 Pair("Content-Type", "application/json"),
                 Pair("Accept", "application/json"),
                 Pair("Unique-Reference-Code", uniqueReferenceCode),
-                Pair("Financial-Id", FINANCIAL_ID),
+                Pair("Financial-Id", bankCode),
                 Pair("Channel-Id", CHANNEL_ID),
             ),
             setPinBody

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/ICardDetailsRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/ICardDetailsRepository.kt
@@ -7,6 +7,7 @@ interface ICardDetailsRepository {
 
     suspend fun getSecuredCardDetails(
         token: String,
+        bankCode: String,
         cardIdentifierId: String,
         cardIdentifierType: String,
         certificate: X509CertificateBodyDto

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/IChangePinRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/IChangePinRepository.kt
@@ -9,15 +9,18 @@ interface IChangePinRepository {
 
     suspend fun getCardsLookUp(
         authToken: String,
+        bankCode: String,
         cardIdentifierBody: CardIdentifierBodyDto
     ): CardIdentifierModel
 
     suspend fun getCertificateFromApiGateway(
-        authToken: String
+        authToken: String,
+        bankCode: String,
     ): PinCertificateModel
 
     suspend fun changePin(
         authToken: String,
+        bankCode: String,
         changePinBody: ChangePinBodyDto
     )
 

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/ISetPinRepository.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/repository/interfaces/ISetPinRepository.kt
@@ -9,15 +9,18 @@ interface ISetPinRepository {
 
     suspend fun getCardsLookUp(
         token: String,
+        bankCode: String,
         cardIdentifierBody: CardIdentifierBodyDto
     ): CardIdentifierModel
 
     suspend fun getPinCertificate(
-        token: String
+        token: String,
+        bankCode: String
     ): PinCertificateModel
 
     suspend fun setPin(
         token: String,
+        bankCode: String,
         setPinBody: SetPinBodyDto
     )
 


### PR DESCRIPTION
SDK bankCode parameter from the NIInput, was previous hardcoded to "EAND" value.
This PR is making bankCode parameter functional by using its value in the code when making calls to the backend.

SampleApp or client should check NIInput object bankCode is set to "EAND" value before running the app.