### PR TITLE
SDK increment version to 1.0.29

### DIFF
--- a/ni_sdk/build.gradle
+++ b/ni_sdk/build.gradle
@@ -82,7 +82,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.network-international'
             artifactId = 'card-management-sdk-android'
-            version = '1.0.28'
+            version = '1.0.29'
             afterEvaluate {
                 from components.release
             }


### PR DESCRIPTION
SDK increment version to 1.0.29 in order to see latest changes related to baseURL check