### PR TITLE
SDK Api21 Set/Change PIN Done button ripple fix

### DIFF
--- a/ni_sdk/build.gradle
+++ b/ni_sdk/build.gradle
@@ -82,7 +82,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.network-international'
             artifactId = 'card-management-sdk-android'
-            version = '1.0.30'
+            version = '1.0.31'
             afterEvaluate {
                 from components.release
             }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/binding_adapters/CustomBindingAdapters.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/binding_adapters/CustomBindingAdapters.kt
@@ -3,14 +3,13 @@ package ae.network.nicardmanagementsdk.presentation.binding_adapters
 import ae.network.nicardmanagementsdk.R
 import ae.network.nicardmanagementsdk.presentation.extension_methods.getThemeColor
 import android.content.res.ColorStateList
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.widget.ImageButton
 import android.widget.ImageView
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.widget.ImageViewCompat.setImageTintList
 import androidx.databinding.BindingAdapter
 
 
@@ -34,13 +33,14 @@ fun setImageViewDisabledColor(imageButton: ImageButton, isDisabled: Boolean) {
 @BindingAdapter("useDisabledBgTint")
 fun setImageViewDisabledBgTint(imageButton: ImageButton, isDisabled: Boolean) {
     val disabledColor = ContextCompat.getColor(imageButton.context, android.R.color.transparent)
-    val enabledColor = ContextCompat.getColor(imageButton.context, R.color.green1)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val enabledColor = ContextCompat.getColor(imageButton.context, R.color.green1)
         imageButton.backgroundTintList = ColorStateList.valueOf(if (isDisabled) disabledColor else enabledColor)
     } else {
-        imageButton.setBackgroundColor(if (isDisabled) disabledColor else enabledColor)
+        val disabledDrawable = ColorDrawable(disabledColor)
+        val normalDrawable = ContextCompat.getDrawable(imageButton.context, R.drawable.done_button_custom_ripple_drawable)
+        imageButton.background = ((if (isDisabled) disabledDrawable else normalDrawable))
     }
-
 }
 
 

--- a/ni_sdk/src/main/res/drawable/done_button_custom_ripple_drawable.xml
+++ b/ni_sdk/src/main/res/drawable/done_button_custom_ripple_drawable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
+    <item android:drawable="@drawable/rectangle_done_normal" />
+</ripple>

--- a/ni_sdk/src/main/res/drawable/rectangle.xml
+++ b/ni_sdk/src/main/res/drawable/rectangle.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@android:color/white" />
-</shape>

--- a/ni_sdk/src/main/res/drawable/rectangle_done_normal.xml
+++ b/ni_sdk/src/main/res/drawable/rectangle_done_normal.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/green1" />
+</shape>


### PR DESCRIPTION
Android SDK API level 21 is suffering from a bug related to View.setBackgroundTintList() method as reported here [https://issuetracker.google.com/issues/37087764](https://issuetracker.google.com/issues/37087764).
This is preventing the proper set of the background tint on the ImageButton on API level 21.

This PR is making a workaround to fix the ripple effect to the Done Set/Change PIN button on API level 21.