### PR TITLE
Change PIN ViewModel two steps

### DIFF
--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/change_pin/ChangePinViewModel.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/change_pin/ChangePinViewModel.kt
@@ -4,51 +4,38 @@ import ae.network.nicardmanagementsdk.R
 import ae.network.nicardmanagementsdk.core.IChangePinCore
 import ae.network.nicardmanagementsdk.network.utils.ConnectionModel
 import ae.network.nicardmanagementsdk.network.utils.IConnection
-import ae.network.nicardmanagementsdk.presentation.ui.set_pin.SetPinViewModelBase
+import ae.network.nicardmanagementsdk.presentation.ui.set_pin.SetPinTwoStepViewModelBase
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.launch
 
-class ChangePinViewModel (
+class ChangePinViewModel(
     private val changePinCoreComponent: IChangePinCore,
-    private val connectionLiveData: IConnection<ConnectionModel>
-) : SetPinViewModelBase() {
+    connectionLiveData: IConnection<ConnectionModel>
+) : SetPinTwoStepViewModelBase(connectionLiveData) {
 
     override val navTitle = MutableLiveData(R.string.change_pin_title)
     override val screenTitle = MutableLiveData(R.string.change_pin_description_enter_current_pin)
-    private var oldPin = ""
-    private var newPin = ""
+
+    private var currentPin = ""
     private var isCurrentPinSetup = true
 
 
     override fun onDoneImageButtonTap() {
         if (isCurrentPinSetup) {
-            oldPin = inputString
-            resetState()
-            screenTitle.value = R.string.change_pin_description_enter_new_pin
-            isCurrentPinSetup = false
+            captureCurrentPin()
         } else {
-            newPin = inputString
-            viewModelScope.launch {
-                if (connectionLiveData.hasInternetConnectivity) {
-                    isVisibleProgressBar.value = true
-                    val result = changePinCoreComponent.makeNetworkRequest(
-                        oldPin,
-                        newPin
-                    )
-                    isVisibleProgressBar.value = false
-                    onResultSingleLiveEvent.value = result
-                }
-            }
+            setPinTwoSteps(networkRequest = {
+                changePinCoreComponent.makeNetworkRequest(
+                    currentPin,
+                    secondTimePinValue
+                )
+            })
         }
     }
 
-    fun resetChangePinState() {
-        oldPin = ""
-        newPin = ""
-        isCurrentPinSetup = true
-        screenTitle.value = R.string.change_pin_description_enter_current_pin
+    private fun captureCurrentPin() {
+        currentPin = inputString
         resetState()
+        screenTitle.value = R.string.change_pin_description_enter_new_pin
+        isCurrentPinSetup = false
     }
-
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinTwoStepViewModelBase.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinTwoStepViewModelBase.kt
@@ -1,0 +1,48 @@
+package ae.network.nicardmanagementsdk.presentation.ui.set_pin
+
+import ae.network.nicardmanagementsdk.R
+import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorResponse
+import ae.network.nicardmanagementsdk.network.utils.ConnectionModel
+import ae.network.nicardmanagementsdk.network.utils.IConnection
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+abstract class SetPinTwoStepViewModelBase(
+    private val connectionLiveData: IConnection<ConnectionModel>
+    ) : SetPinViewModelBase() {
+
+    private var firstTimePinValue = ""
+    protected var secondTimePinValue = ""
+    private var isStepOnePinSetup = true
+
+    private fun resetStepTwoPinState() {
+        secondTimePinValue = ""
+        resetState()
+    }
+
+    protected fun setPinTwoSteps(
+        networkRequest: suspend () -> SuccessErrorResponse
+    ) {
+        if (isStepOnePinSetup) {
+            firstTimePinValue = inputString
+            resetState()
+            screenTitle.value = R.string.set_pin_description_re_enter_pin
+            isStepOnePinSetup = false
+        } else {
+            secondTimePinValue = inputString
+            if (firstTimePinValue == secondTimePinValue) {
+                viewModelScope.launch {
+                    if (connectionLiveData.hasInternetConnectivity) {
+                        isVisibleProgressBar.value = true
+                        val result = networkRequest()
+                        isVisibleProgressBar.value = false
+                        onResultSingleLiveEvent.value = result
+                    }
+                }
+            } else {
+                screenTitle.value = R.string.set_pin_description_pin_not_match
+                resetStepTwoPinState()
+            }
+        }
+    }
+}

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinViewModel.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinViewModel.kt
@@ -5,47 +5,16 @@ import ae.network.nicardmanagementsdk.core.ISetVerifyPinCore
 import ae.network.nicardmanagementsdk.network.utils.ConnectionModel
 import ae.network.nicardmanagementsdk.network.utils.IConnection
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.launch
 
 class SetPinViewModel (
     private val setVerifyPinCore: ISetVerifyPinCore,
-    private val connectionLiveData: IConnection<ConnectionModel>
-) : SetPinViewModelBase() {
+    connectionLiveData: IConnection<ConnectionModel>
+) : SetPinTwoStepViewModelBase(connectionLiveData) {
 
     override val navTitle = MutableLiveData(R.string.set_pin_title)
     override val screenTitle = MutableLiveData(R.string.set_pin_description_enter_pin)
 
-    private var firstTimePinValue = ""
-    private var secondTimePinValue = ""
-    private var isStepOnePinSetup = true
-
     override fun onDoneImageButtonTap() {
-        if (isStepOnePinSetup) {
-            firstTimePinValue = inputString
-            resetState()
-            screenTitle.value = R.string.set_pin_description_re_enter_pin
-            isStepOnePinSetup = false
-        } else {
-            secondTimePinValue = inputString
-            if (firstTimePinValue == secondTimePinValue) {
-                viewModelScope.launch {
-                    if (connectionLiveData.hasInternetConnectivity) {
-                        isVisibleProgressBar.value = true
-                        val result = setVerifyPinCore.makeNetworkRequest(inputString)
-                        isVisibleProgressBar.value = false
-                        onResultSingleLiveEvent.value = result
-                    }
-                }
-            } else {
-                screenTitle.value = R.string.set_pin_description_pin_not_match
-                resetStepTwoPinState()
-            }
-        }
-    }
-
-    private fun resetStepTwoPinState() {
-        secondTimePinValue = ""
-        resetState()
+        setPinTwoSteps(networkRequest = { setVerifyPinCore.makeNetworkRequest(secondTimePinValue) })
     }
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinViewModelBase.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinViewModelBase.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.Transformations
 
 abstract class SetPinViewModelBase : BaseViewModel() {
 
-    abstract val navTitle: LiveData<Int>
-    abstract val screenTitle: LiveData<Int>
+    abstract val navTitle: MutableLiveData<Int>
+    abstract val screenTitle: MutableLiveData<Int>
     abstract fun onDoneImageButtonTap()
 
     private var _inputString = ""


### PR DESCRIPTION
Change PIN flow has changed to:
- capture old PIN
- capture new PIN with two step validation
An refactoring has been made to reuse the code from set PIN viewModel with two steps