### PR TITLE
Adding the SuccessErrorCancelResponse support

### DIFF
--- a/ni_sdk/build.gradle
+++ b/ni_sdk/build.gradle
@@ -82,7 +82,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.network-international'
             artifactId = 'card-management-sdk-android'
-            version = '1.0.36'
+            version = '1.0.37'
             afterEvaluate {
                 from components.release
             }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/api/interfaces/NICardManagementAPI.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/api/interfaces/NICardManagementAPI.kt
@@ -2,6 +2,7 @@ package ae.network.nicardmanagementsdk.api.interfaces
 
 import ae.network.nicardmanagementsdk.api.models.output.NICardDetailsResponse
 import ae.network.nicardmanagementsdk.api.models.input.NIInput
+import ae.network.nicardmanagementsdk.api.models.output.NICancelledResponse
 import ae.network.nicardmanagementsdk.api.models.output.NIErrorResponse
 import ae.network.nicardmanagementsdk.api.models.output.NISuccessResponse
 import java.lang.Exception
@@ -28,6 +29,12 @@ interface NICardManagementAPI {
         input: NIInput
     ): SuccessErrorResponse
 }
+
+data class SuccessErrorCancelResponse(
+    val isSuccess: NISuccessResponse?,
+    val isError: NIErrorResponse?,
+    val isCancelled: NICancelledResponse?
+)
 
 data class SuccessErrorResponse(
     val isSuccess: NISuccessResponse?,
@@ -63,5 +70,13 @@ fun DetailsErrorResponse.asSuccessErrorResponse(): SuccessErrorResponse {
            NISuccessResponse()
         },
         isError
+    )
+}
+
+fun SuccessErrorResponse.asSuccessErrorCancelResponse(): SuccessErrorCancelResponse {
+    return SuccessErrorCancelResponse(
+        isSuccess,
+        isError,
+        null
     )
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/api/models/output/NICancelledResponse.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/api/models/output/NICancelledResponse.kt
@@ -1,0 +1,7 @@
+package ae.network.nicardmanagementsdk.api.models.output
+
+import java.io.Serializable
+
+data class NICancelledResponse(
+    val cancelMessage: String = "The action was cancelled by the user"
+): Serializable

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/change_pin/ChangePinFragment.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/change_pin/ChangePinFragment.kt
@@ -1,6 +1,8 @@
 package ae.network.nicardmanagementsdk.presentation.ui.change_pin
 
+import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorResponse
+import ae.network.nicardmanagementsdk.api.interfaces.asSuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.models.input.NIInput
 import ae.network.nicardmanagementsdk.di.Injector
 import ae.network.nicardmanagementsdk.presentation.ui.set_pin.SetPinDialogFragmentBase
@@ -42,7 +44,7 @@ abstract class ChangePinFragment : SetPinDialogFragmentBase<ChangePinViewModel>(
             successErrorResponse?.let { response ->
                 lifecycleScope.launch {
                     delay(500)
-                    this@ChangePinFragment.successErrorResponse = response
+                    this@ChangePinFragment.successErrorCancelResponse = response.asSuccessErrorCancelResponse()
                     niInput.displayAttributes?.changePinMessageAttributes?.let {
                         showSuccessErrorFragment(it,response.isSuccess != null)
                     } ?: dismiss()
@@ -53,10 +55,10 @@ abstract class ChangePinFragment : SetPinDialogFragmentBase<ChangePinViewModel>(
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        successErrorResponse?.let { listener?.onChangePinFragmentCompletion(it) }
+        listener?.onChangePinFragmentCompletion(successErrorCancelResponse)
     }
 
     interface OnFragmentInteractionListener {
-        fun onChangePinFragmentCompletion(response: SuccessErrorResponse)
+        fun onChangePinFragmentCompletion(response: SuccessErrorCancelResponse)
     }
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinDialogFragmentBase.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinDialogFragmentBase.kt
@@ -1,10 +1,11 @@
 package ae.network.nicardmanagementsdk.presentation.ui.set_pin
 
 import ae.network.nicardmanagementsdk.R
-import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorResponse
+import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.models.input.NIInput
 import ae.network.nicardmanagementsdk.api.models.input.NIPinFormType
 import ae.network.nicardmanagementsdk.api.models.input.PinMessageAttributes
+import ae.network.nicardmanagementsdk.api.models.output.NICancelledResponse
 import ae.network.nicardmanagementsdk.databinding.ActivitySetPinBinding
 import ae.network.nicardmanagementsdk.helpers.ThemeHelper
 import ae.network.nicardmanagementsdk.presentation.adapters.BulletListAdapter
@@ -26,7 +27,11 @@ abstract class SetPinDialogFragmentBase<T : SetPinViewModelBase> : DialogFragmen
         get() = _binding!!
 
     private lateinit var niPinFormType: NIPinFormType
-    protected var successErrorResponse: SuccessErrorResponse? = null
+    protected var successErrorCancelResponse = SuccessErrorCancelResponse(
+        isSuccess = null,
+        isError = null,
+        isCancelled = NICancelledResponse()
+    )
     lateinit var niInput: NIInput
     abstract var viewModel: T
 

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinFragment.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/set_pin/SetPinFragment.kt
@@ -1,6 +1,7 @@
 package ae.network.nicardmanagementsdk.presentation.ui.set_pin
 
-import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorResponse
+import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorCancelResponse
+import ae.network.nicardmanagementsdk.api.interfaces.asSuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.models.input.NIInput
 import ae.network.nicardmanagementsdk.di.Injector
 import android.content.DialogInterface
@@ -42,7 +43,7 @@ abstract class SetPinFragment : SetPinDialogFragmentBase<SetPinViewModel>() {
             successErrorResponse?.let { response ->
                 lifecycleScope.launch {
                     delay(500)
-                    this@SetPinFragment.successErrorResponse = response
+                    this@SetPinFragment.successErrorCancelResponse = response.asSuccessErrorCancelResponse()
                     niInput.displayAttributes?.setPinMessageAttributes?.let {
                         showSuccessErrorFragment(it,response.isSuccess != null)
                     } ?: dismiss()
@@ -53,10 +54,10 @@ abstract class SetPinFragment : SetPinDialogFragmentBase<SetPinViewModel>() {
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        successErrorResponse?.let { listener?.onSetPinFragmentCompletion(it) }
+        listener?.onSetPinFragmentCompletion(successErrorCancelResponse)
     }
 
     interface OnFragmentInteractionListener {
-        fun onSetPinFragmentCompletion(response: SuccessErrorResponse)
+        fun onSetPinFragmentCompletion(response: SuccessErrorCancelResponse)
     }
 }

--- a/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/verify_pin/VerifyPinFragment.kt
+++ b/ni_sdk/src/main/java/ae/network/nicardmanagementsdk/presentation/ui/verify_pin/VerifyPinFragment.kt
@@ -1,6 +1,8 @@
 package ae.network.nicardmanagementsdk.presentation.ui.verify_pin
 
+import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.interfaces.SuccessErrorResponse
+import ae.network.nicardmanagementsdk.api.interfaces.asSuccessErrorCancelResponse
 import ae.network.nicardmanagementsdk.api.models.input.NIInput
 import ae.network.nicardmanagementsdk.di.Injector
 import ae.network.nicardmanagementsdk.presentation.ui.set_pin.SetPinDialogFragmentBase
@@ -42,7 +44,7 @@ abstract class VerifyPinFragment : SetPinDialogFragmentBase<VerifyPinViewModel>(
             successErrorResponse?.let { response ->
                 lifecycleScope.launch {
                     delay(500)
-                    this@VerifyPinFragment.successErrorResponse = response
+                    this@VerifyPinFragment.successErrorCancelResponse = response.asSuccessErrorCancelResponse()
                     niInput.displayAttributes?.verifyPinMessageAttributes?.let {
                         showSuccessErrorFragment(it,response.isSuccess != null)
                     } ?: dismiss()
@@ -53,10 +55,10 @@ abstract class VerifyPinFragment : SetPinDialogFragmentBase<VerifyPinViewModel>(
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        successErrorResponse?.let { listener?.onVerifyPinFragmentCompletion(it) }
+        listener?.onVerifyPinFragmentCompletion(successErrorCancelResponse)
     }
 
     interface OnFragmentInteractionListener {
-        fun onVerifyPinFragmentCompletion(response: SuccessErrorResponse)
+        fun onVerifyPinFragmentCompletion(response: SuccessErrorCancelResponse)
     }
 }


### PR DESCRIPTION
Verify/Set/Change PIN dialog fragment send a callback on completion, with success/error message. This PR is adding the support for SuccessErrorCancelResponse which include the "cancelled by the user" scenario in the callback message.

> data class SuccessErrorCancelResponse(
>     val isSuccess: NISuccessResponse?,
>     val isError: NIErrorResponse?,
>     val isCancelled: NICancelledResponse?
> )

If the user navigate back before the network request is completed (with success or error response) the cancelled scenario will be send to the subscriber by the callback, i.e:

> SuccessErrorCancelResponse(
>         isSuccess = null,
>         isError = null,
>         isCancelled = NICancelledResponse()
>     )

These changes accomplish the client request regarding the cancellation scenario.

On the client side the callback implementation will look like this:

> override fun onVerifyPinFragmentCompletion(response: SuccessErrorCancelResponse) {
>
>         response.isSuccess?.let {
>             Log.d(TAG, "VerifyPinFragmentFromActivity ${it.message}")
>         }
>
>         response.isError?.let {
>             Log.d(TAG, "VerifyPinFragmentFromActivity ${it.errorMessage}")
>         }
> 
>         response.isCancelled?.let {
>             Log.d(TAG, "VerifyPinFragmentFromActivity ${it.cancelMessage}")
>         }
>     }